### PR TITLE
Catch Notifier Exceptions

### DIFF
--- a/src/Components/Component.php
+++ b/src/Components/Component.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tylercd100\LERN\Components;
+
+use Exception;
+
+abstract class Component {
+
+    /**
+     * @var array
+     */
+    protected $dontHandle = [];
+
+    /**
+     * @var array
+     */
+    private $absolutelyDontHandle = [
+        Tylercd100\LERN\Exceptions\LERNExceptionInterface::class,
+    ];
+
+    /**
+     * Determine if the exception is in the "do not report" list.
+     *
+     * @param  \Exception  $e
+     * @return bool
+     */
+    protected function shouldHandle(Exception $e){
+        return !$this->shouldHandle($e);
+    }
+
+    /**
+     * Determine if the exception is in the "do not report" list.
+     *
+     * @param  \Exception  $e
+     * @return bool
+     */
+    protected function shouldntHandle(Exception $e){
+        $dontHandle = array_merge($this->dontHandle,$this->absolutelyDontHandle);
+
+        foreach ($dontHandle as $type) {
+            if ($e instanceof $type) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Components/Component.php
+++ b/src/Components/Component.php
@@ -15,21 +15,12 @@ abstract class Component {
      * @var array
      */
     private $absolutelyDontHandle = [
-        Tylercd100\LERN\Exceptions\LERNExceptionInterface::class,
+        \Tylercd100\LERN\Exceptions\RecorderFailedException::class,
+        \Tylercd100\LERN\Exceptions\NotifierFailedException::class,
     ];
 
     /**
-     * Determine if the exception is in the "do not report" list.
-     *
-     * @param  \Exception  $e
-     * @return bool
-     */
-    protected function shouldHandle(Exception $e){
-        return !$this->shouldHandle($e);
-    }
-
-    /**
-     * Determine if the exception is in the "do not report" list.
+     * Determine if the exception is in the "do not handle" list.
      *
      * @param  \Exception  $e
      * @return bool

--- a/src/Components/Notifier.php
+++ b/src/Components/Notifier.php
@@ -116,8 +116,12 @@ class Notifier {
             $this->log->pushHandler($handler);
         }
 
-        $this->log->addCritical($message);
-
+        try{
+            $this->log->addCritical($message);
+        } catch (Exception $e) {
+            dd("LERN notifier failed. Message: {$e->getMessage()}.".PHP_EOL.$e->getTraceAsString());
+        }
+        
         return $this;
     }
 }

--- a/src/Components/Notifier.php
+++ b/src/Components/Notifier.php
@@ -109,17 +109,18 @@ class Notifier extends Component {
      * @return bool
      */
     public function send(Exception $e, array $context = []) {
+        
+        if($this->shouldntHandle($e)){
+            return false;
+        }
+
+        $factory = new MonologHandlerFactory();
+        $drivers = $this->drivers;
+
+        $message = $this->getMessage($e);
+        $subject = $this->getSubject($e);
+        
         try{
-            if($this->shouldntHandle($e)){
-                return false;
-            }
-
-            $factory = new MonologHandlerFactory();
-            $drivers = $this->drivers;
-
-            $message = $this->getMessage($e);
-            $subject = $this->getSubject($e);
-            
             foreach ($drivers as $driver) {
                 $handler = $factory->create($driver, $subject);
                 $this->log->pushHandler($handler);

--- a/src/Components/Notifier.php
+++ b/src/Components/Notifier.php
@@ -6,8 +6,9 @@ use Exception;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
 use Tylercd100\LERN\Factories\MonologHandlerFactory;
+use Tylercd100\LERN\Exceptions\NotifierFailedException;
 
-class Notifier {
+class Notifier extends Component {
     protected $config;
     protected $log;
     protected $messageCb;
@@ -105,30 +106,33 @@ class Notifier {
      * Triggers the Monolog Logger instance to log an error to all handlers
      * @param  Exception $e The exception to use
      * @param  array $context Additional information that you would like to pass to Monolog
-     * @return boolean Returns if successful returns true else false
+     * @return bool
      */
     public function send(Exception $e, array $context = []) {
-        $factory = new MonologHandlerFactory();
-        $drivers = $this->drivers;
-
-        $message = $this->getMessage($e);
-        $subject = $this->getSubject($e);
-        
-        foreach ($drivers as $driver) {
-            $handler = $factory->create($driver, $subject);
-            $this->log->pushHandler($handler);
-        }
-
-        $context = $this->buildContext($context);
-
         try{
-            $this->log->addCritical($message, $context);
-        } catch (Exception $e) {
-            echo "LERN notifier failed. Message: {$e->getMessage()}.".PHP_EOL.$e->getTraceAsString();
-            return false;
-        }
+            if($this->shouldntHandle($e)){
+                return false;
+            }
 
-        return true;
+            $factory = new MonologHandlerFactory();
+            $drivers = $this->drivers;
+
+            $message = $this->getMessage($e);
+            $subject = $this->getSubject($e);
+            
+            foreach ($drivers as $driver) {
+                $handler = $factory->create($driver, $subject);
+                $this->log->pushHandler($handler);
+            }
+
+            $context = $this->buildContext($context);
+
+            $this->log->addCritical($message, $context);
+
+            return true;
+        } catch (Exception $e) {
+            throw new NotifierFailedException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 
     /**

--- a/src/Components/Notifier.php
+++ b/src/Components/Notifier.php
@@ -102,7 +102,7 @@ class Notifier {
     /**
      * Triggers the Monolog Logger instance to log an error to all handlers
      * @param  Exception $e The exception to use
-     * @return Notifier     Returns this
+     * @return Notifier|false Returns this
      */
     public function send(Exception $e) {
         $factory = new MonologHandlerFactory();
@@ -119,9 +119,10 @@ class Notifier {
         try{
             $this->log->addCritical($message);
         } catch (Exception $e) {
-            dd("LERN notifier failed. Message: {$e->getMessage()}.".PHP_EOL.$e->getTraceAsString());
+            echo "LERN notifier failed. Message: {$e->getMessage()}.".PHP_EOL.$e->getTraceAsString();
+            return false;
         }
-        
+
         return $this;
     }
 }

--- a/src/Components/Recorder.php
+++ b/src/Components/Recorder.php
@@ -31,23 +31,23 @@ class Recorder extends Component{
      */
     public function record(Exception $e)
     {
+        if($this->shouldntHandle($e)){
+            return false;
+        }
+
+        $opts = [
+            'class'       => get_class($e),
+            'file'        => $e->getFile(),
+            'line'        => $e->getLine(),
+            'code'        => $e->getCode(),
+            'message'     => $e->getMessage(),
+            'trace'       => $e->getTraceAsString(),
+        ];
+
+
+        $configDependant = ['user_id', 'status_code', 'method', 'data', 'url'];
+
         try {
-            if($this->shouldntHandle($e)){
-                return false;
-            }
-
-            $opts = [
-                'class'       => get_class($e),
-                'file'        => $e->getFile(),
-                'line'        => $e->getLine(),
-                'code'        => $e->getCode(),
-                'message'     => $e->getMessage(),
-                'trace'       => $e->getTraceAsString(),
-            ];
-
-
-            $configDependant = ['user_id', 'status_code', 'method', 'data', 'url'];
-
             foreach ($configDependant as $key) {
                 if ($this->canCollect($key)) {
                     $opts[$key] = $this->collect($key, $e);
@@ -81,12 +81,14 @@ class Recorder extends Component{
                 return $this->getUserId();
             case 'method':
                 return $this->getMethod();
-            case 'status_code':
-                return $this->getStatusCode($e);
             case 'url':
                 return $this->getUrl();
             case 'data':
                 return $this->getData();
+            case 'status_code':
+                if($e===null)
+                    return 0;
+                return $this->getStatusCode($e);
             default:
                 throw new Exception("{$key} is not supported! Therefore it cannot be collected!");
         }

--- a/src/Exceptions/LERNExceptionInterface.php
+++ b/src/Exceptions/LERNExceptionInterface.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Tylercd100\LERN\Exceptions;
-
-interface LERNExceptionInterface {
-
-}

--- a/src/Exceptions/LERNExceptionInterface.php
+++ b/src/Exceptions/LERNExceptionInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Tylercd100\LERN\Exceptions;
+
+interface LERNExceptionInterface {
+
+}

--- a/src/Exceptions/NotifierFailedException.php
+++ b/src/Exceptions/NotifierFailedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Tylercd100\LERN\Exceptions;
+
+class NotifierFailedException extends \Exception implements LERNExceptionInterface{
+
+}

--- a/src/Exceptions/NotifierFailedException.php
+++ b/src/Exceptions/NotifierFailedException.php
@@ -2,6 +2,6 @@
 
 namespace Tylercd100\LERN\Exceptions;
 
-class NotifierFailedException extends \Exception implements LERNExceptionInterface{
+class NotifierFailedException extends \Exception{
 
 }

--- a/src/Exceptions/RecorderFailedException.php
+++ b/src/Exceptions/RecorderFailedException.php
@@ -2,6 +2,6 @@
 
 namespace Tylercd100\LERN\Exceptions;
 
-class RecorderFailedException extends \Exception implements LERNExceptionInterface{
+class RecorderFailedException extends \Exception{
 
 }

--- a/src/Exceptions/RecorderFailedException.php
+++ b/src/Exceptions/RecorderFailedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Tylercd100\LERN\Exceptions;
+
+class RecorderFailedException extends \Exception implements LERNExceptionInterface{
+
+}

--- a/src/Factories/MonologHandlerFactory.php
+++ b/src/Factories/MonologHandlerFactory.php
@@ -84,7 +84,7 @@ class MonologHandlerFactory {
     /**
      * Creates Mail Monolog Handler
      * @param  string $subject Title or Subject line for the notification
-     * @return \Monolog\Handler\NativeMailerHandler A handler to use with a Monolog\Logger instance
+     * @return \Monolog\Handler\NativeMailerHandler|Monolog\Handler\SwiftMailerHandler A handler to use with a Monolog\Logger instance
      */
     protected function mail($subject)
     {

--- a/src/LERN.php
+++ b/src/LERN.php
@@ -59,7 +59,7 @@ class LERN
     /**
      * Stores the exception in the database
      * @param  Exception $e   The exception to use
-     * @return \Tylercd100\LERN\Models\ExceptionModel The recorded Exception as an Eloquent Model
+     * @return \Tylercd100\LERN\Models\ExceptionModel|false The recorded Exception as an Eloquent Model
      */
     public function record(Exception $e)
     {

--- a/tests/LERNTest.php
+++ b/tests/LERNTest.php
@@ -5,6 +5,7 @@ namespace Tylercd100\LERN\Tests;
 use Tylercd100\LERN\LERN;
 use Tylercd100\LERN\Factories\MonologHandlerFactory;
 use Tylercd100\LERN\Components\Notifier;
+use Tylercd100\LERN\Components\Recorder;
 use Exception;
 
 class LERNTest extends TestCase
@@ -84,5 +85,13 @@ class LERNTest extends TestCase
         $lern->setNotifier($orig_notifier);
         $new_notifier = $lern->getNotifier();
         $this->assertEquals($new_notifier,$orig_notifier);
+    }
+
+    public function testSettingAndGettingACustomRecorderInstance(){
+        $lern = new LERN;
+        $orig_recorder = new Recorder;
+        $lern->setRecorder($orig_recorder);
+        $new_recorder = $lern->getRecorder();
+        $this->assertEquals($new_recorder,$orig_recorder);
     }
 }

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -5,6 +5,7 @@ namespace Tylercd100\LERN\Tests;
 use Exception;
 use Tylercd100\LERN\Components\Notifier;
 use Tylercd100\LERN\Factories\MonologHandlerFactory;
+use Tylercd100\LERN\Exceptions\NotifierFailedException;
 
 class NotifierTest extends TestCase
 {
@@ -85,4 +86,9 @@ class NotifierTest extends TestCase
         $subject->send(new Exception);
     }
 
+    public function testSendShouldReturnFalseWhenPassedNotifierFailedException(){
+        $notifier = new Notifier;
+        $result = $notifier->send(new NotifierFailedException);
+        $this->assertEquals(false,$result);
+    }
 }

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -75,7 +75,7 @@ class NotifierTest extends TestCase
         $observer = $this->getMock('Monolog\Logger',['addCritical'],['channelName']);
 
         $observer->expects($this->once())
-                 ->method('addCritical');
+                 ->method('addCritical')
                  ->will($this->throwException(new Exception));
         
         $this->expectOutputRegex("/LERN notifier failed/");

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -68,4 +68,21 @@ class NotifierTest extends TestCase
         $this->assertEquals($result,"This is a test");
     }
 
+    public function testItDumpsErrorMessageWhenMonologThrowsException(){
+
+        $handler = (new MonologHandlerFactory())->create('slack');
+
+        $observer = $this->getMock('Monolog\Logger',['addCritical'],['channelName']);
+
+        $observer->expects($this->once())
+                 ->method('addCritical');
+                 ->will($this->throwException(new Exception));
+        
+        $this->expectOutputRegex("/LERN notifier failed/");
+
+        $subject = new Notifier($observer);
+        $subject->pushHandler($handler);
+        $subject->send(new Exception);
+    }
+
 }

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -68,7 +68,7 @@ class NotifierTest extends TestCase
         $this->assertEquals($result,"This is a test");
     }
 
-    public function testItDumpsErrorMessageWhenMonologThrowsException(){
+    public function testItThrowsNotifierFailedExceptionWhenMonologThrowsException(){
 
         $handler = (new MonologHandlerFactory())->create('slack');
 

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -78,7 +78,7 @@ class NotifierTest extends TestCase
                  ->method('addCritical')
                  ->will($this->throwException(new Exception));
         
-        $this->expectOutputRegex("/LERN notifier failed/");
+        $this->setExpectedException('Tylercd100\LERN\Exceptions\NotifierFailedException');
 
         $subject = new Notifier($observer);
         $subject->pushHandler($handler);

--- a/tests/RecorderTest.php
+++ b/tests/RecorderTest.php
@@ -7,18 +7,34 @@ use Exception;
 
 class RecorderTest extends TestCase
 {
-    public function testCollectMethodReturnsFalseWhenConfigValuesAreFalse(){
+    public function setUp()
+    {
+        parent::setUp();
         $this->migrate();
-        $this->app['config']->set('lern.record.collect', [
-            'method'=>false,//When true it will collect GET, POST, DELETE, PUT, etc...
-            'data'=>false,//When true it will collect Input data
-            'status_code'=>false,
-            'user_id'=>false,
-            'url'=>false,
-        ]);
+    }
+
+    public function tearDown()
+    {
+        $this->migrateReset();
+        parent::tearDown();        
+    }
+
+    public function testCollectMethodReturnsFalseWhenConfigValuesAreFalse(){
+        $this->app['config']->set('lern.record.collect', ['method'=>false,'data'=>false,'status_code'=>false,'user_id'=>false,'url'=>false,]);
         $recorder = new Recorder;
         $model = $recorder->record(new Exception);
         $this->assertEquals($model->url,null);
-        $this->migrateReset();
+    }
+
+    public function testItThrowsRecorderFailedExceptionWhenExceptionIsThrown(){
+        $mock = $this->getMock(Recorder::class,['collect']);
+
+        $mock->expects($this->once())
+                 ->method('collect')
+                 ->will($this->throwException(new Exception));
+        
+        $this->setExpectedException('Tylercd100\LERN\Exceptions\RecorderFailedException');
+
+        $mock->record(new Exception);
     }
 }

--- a/tests/RecorderTest.php
+++ b/tests/RecorderTest.php
@@ -3,6 +3,7 @@
 namespace Tylercd100\LERN\Tests;
 
 use Tylercd100\LERN\Components\Recorder;
+use Tylercd100\LERN\Exceptions\RecorderFailedException;
 use Exception;
 
 class RecorderTest extends TestCase
@@ -33,8 +34,15 @@ class RecorderTest extends TestCase
                  ->method('collect')
                  ->will($this->throwException(new Exception));
         
-        $this->setExpectedException('Tylercd100\LERN\Exceptions\RecorderFailedException');
+        $this->setExpectedException(RecorderFailedException::class);
 
         $mock->record(new Exception);
     }
+
+    public function testRecordShouldReturnFalseWhenPassedRecorderFailedException(){
+        $recorder = new Recorder;
+        $result = $recorder->record(new RecorderFailedException);
+        $this->assertEquals(false,$result);
+    }
+
 }

--- a/tests/RecorderTest.php
+++ b/tests/RecorderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tylercd100\LERN\Tests;
+
+use Tylercd100\LERN\Components\Recorder;
+use Exception;
+
+class RecorderTest extends TestCase
+{
+    public function testCollectMethodReturnsFalseWhenConfigValuesAreFalse(){
+        $this->migrate();
+        $this->app['config']->set('lern.record.collect', [
+            'method'=>false,//When true it will collect GET, POST, DELETE, PUT, etc...
+            'data'=>false,//When true it will collect Input data
+            'status_code'=>false,
+            'user_id'=>false,
+            'url'=>false,
+        ]);
+        $recorder = new Recorder;
+        $model = $recorder->record(new Exception);
+        $this->assertEquals($model->url,null);
+        $this->migrateReset();
+    }
+}


### PR DESCRIPTION
This will fix an infinite loop caused by the notifier when it fails to send a notification through any channel such as Email.
.
