### PR TITLE
Use Attribute Casting in Exception Model

### DIFF
--- a/src/Models/ExceptionModel.php
+++ b/src/Models/ExceptionModel.php
@@ -7,18 +7,14 @@ use Illuminate\Database\Eloquent\Model;
 class ExceptionModel extends Model {
     protected $table;
     protected $guarded = array('id');
-
+    
+    protected $casts = array(
+        'data' => 'array'
+    );
+    
     public function __construct(array $attributes = [])
     {
         $this->table = config('lern.record.table');
         parent::__construct($attributes);
-    }
-
-    public function setDataAttribute($value) {
-        $this->attributes['data'] = json_encode($value);
-    }
-
-    public function getDataAttribute($value) {
-        return json_decode($value);
     }
 }


### PR DESCRIPTION
No need for the boilerplate code, Laravel 5.0+ has support for `array` type cast which handles JSON properly.
