### PR TITLE
Fixes the "php artisan migrate:refresh" error.

### DIFF
--- a/migrations/2016_03_27_000000_add_user_data_and_url_to_lern_tables.php
+++ b/migrations/2016_03_27_000000_add_user_data_and_url_to_lern_tables.php
@@ -28,10 +28,10 @@ class AddUserDataAndUrlToLernTables extends Migration {
     public function down()
     {
         Schema::table(config('lern.record.table'), function(Blueprint $table) {
-            $table->dropColumn('user_id');
-            $table->dropColumn('data');
-            $table->dropColumn('url');
-            $table->dropColumn('method');
+            // $table->dropColumn('user_id');
+            // $table->dropColumn('data');
+            // $table->dropColumn('url');
+            // $table->dropColumn('method');
         });
     }
 


### PR DESCRIPTION
You can't drop columns after you already deleted the table.
