### PR TITLE
Updated README to handle edge case when LERN not yet installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,19 @@ To use LERN modify the report method in the `app/Exceptions/Handler.php` file
 ```php
 public function report(Exception $e)
 {
-	if ($this->shouldReport($e)) {
-	    LERN::handle($e); //Record and Notify the Exception
-	    /*
-	    OR...
-	    LERN::record($e); //Record the Exception to the database
-	    LERN::notify($e); //Notify the Exception
-	    */
-	}
+    if ($this->shouldReport($e)) {
+        if (app()->bound("lern")) {
+            app()->make("lern")->handle($e); //Record and Notify the Exception
+
+            /*
+            OR...
+            app()->make("lern")->record($e); //Record the Exception to the database
+            app()->make("lern")->notify($e); //Notify the Exception
+            */
+        }
+    }
 	
-	return parent::report($e);
+    return parent::report($e);
 }
 ```
 


### PR DESCRIPTION
Currently if an exception is thrown doing a `composer install` all exceptions get thrown as `PHP Fatal error:  Call to undefined method Tylercd100\LERN\Facades\LERN::handle()`

By doing a `bound` check we can make it so that the actual exception will get passed through if LERN is not yet installed.
