### PR TITLE
BugFix excludeKeys not working. Return filtered  array.

### DIFF
--- a/src/Components/Recorder.php
+++ b/src/Components/Recorder.php
@@ -135,8 +135,7 @@ class Recorder extends Component {
     protected function getData() {
         $data = Input::all();
         if (is_array($data)) {
-            $this->excludeKeys($data);
-            return $data;
+            return $this->excludeKeys($data);
         } else {
             return null;
         }


### PR DESCRIPTION
Fix for #42.
Returning filtered data array.
/s